### PR TITLE
update lifecycle of external lambda

### DIFF
--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -95,6 +95,7 @@ resource "aws_lambda_function" "lambda_external" {
       filename,
       source_code_hash,
       last_modified,
+      layers,
     ]
   }
 }


### PR DESCRIPTION
There is a requirement to add layers into lifecycle, cause it creates problems during multiple deployments of the infrastructure.